### PR TITLE
Validations & Schemas for parsers

### DIFF
--- a/data_parser/base_parser.py
+++ b/data_parser/base_parser.py
@@ -54,23 +54,11 @@ class BaseParser:
             
             # If validation failed, move output into a separate file for debugging
             if validation_error:
+                self.thread_print(f"Error validating {self.file}. Check debug file for more info.\n", validation_error)
+
                 timestamp = time.time()
-
-                self.thread_print(f"Error validating {self.file}. Check debug files for more info.")
-                json_output = self.create_file(f.name + f"_DEBUG_{timestamp}.json")
-                stacktrace_file = self.create_file(f.name + f"_DEBUG_{timestamp}.txt")
-
-                json.dump(data, json_output)
-
-                # Replace contents of original json with error message
-                f.truncate(0)
-                json.dump({'error': 'Error validating this data file. Check the debug files for more info.'}, f)
-
-                # Write stacktrace
-                stacktrace_file.write(repr(validation_error))
-
-                json_output.close()
-                stacktrace_file.close()
+                with self.create_file(f.name + f"_DEBUG_{timestamp}.txt") as stacktrace_file:
+                    stacktrace_file.write(repr(validation_error))
 
     def create_file(self, path):
         return open(path, 'x')

--- a/data_parser/base_parser.py
+++ b/data_parser/base_parser.py
@@ -64,7 +64,7 @@ class BaseParser:
 
                 # Replace contents of original json with error message
                 f.truncate(0)
-                json.dump({'error': 5}, f)
+                json.dump({'error': 'Error validating this data file. Check the debug files for more info.'}, f)
 
                 # Write stacktrace
                 stacktrace_file.write(repr(validation_error))

--- a/data_parser/base_parser.py
+++ b/data_parser/base_parser.py
@@ -87,3 +87,6 @@ class BaseParser:
         self.load_file()
         self.process()
         self.dump_file()
+
+        self.thread_print(f"Validating {self.file}...")
+        self.validate_dump()

--- a/data_parser/buildings.py
+++ b/data_parser/buildings.py
@@ -4,6 +4,7 @@ from datetime import datetime
 import requests
 
 from data_parser.base_parser import BaseParser
+from validations.schemas.buildings_schema import BuildingsSchema
 
 
 class BuildingsParser(BaseParser):
@@ -18,7 +19,8 @@ class BuildingsParser(BaseParser):
 
     def __init__(self):
         super().__init__(
-            file="../data/buildings.json"
+            file="../data/buildings.json",
+            schema=BuildingsSchema
         )
 
     def process(self):
@@ -60,4 +62,6 @@ class BuildingsParser(BaseParser):
 
 if __name__ == "__main__":
     p = BuildingsParser()
-    p.run()
+    # p.run()
+    p.thread_print(f"Validating {p.file}...")
+    p.validate_dump()

--- a/data_parser/buildings.py
+++ b/data_parser/buildings.py
@@ -62,6 +62,4 @@ class BuildingsParser(BaseParser):
 
 if __name__ == "__main__":
     p = BuildingsParser()
-    # p.run()
-    p.thread_print(f"Validating {p.file}...")
-    p.validate_dump()
+    p.run()

--- a/data_parser/courses.py
+++ b/data_parser/courses.py
@@ -243,3 +243,6 @@ if __name__ == "__main__":
     p.queue.join()
     p.clean_up()
     p.dump_file()
+
+    p.thread_print(f"Validating {p.file}...")
+    p.validate_dump()

--- a/data_parser/courses.py
+++ b/data_parser/courses.py
@@ -8,6 +8,7 @@ import requests
 from bs4 import BeautifulSoup
 
 from data_parser.base_parser import BaseParser
+from validations.schemas.courses_schema import CoursesSchema
 
 
 class CoursesParser(BaseParser):
@@ -15,7 +16,8 @@ class CoursesParser(BaseParser):
 
     def __init__(self):
         super().__init__(
-            file="../data/courses.json"
+            file="../data/courses.json",
+            schema=CoursesSchema
         )
 
     def fill_queue(self, extract=False):

--- a/data_parser/evals.py
+++ b/data_parser/evals.py
@@ -17,6 +17,7 @@ from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 
 from data_parser.base_parser import BaseParser
+from validations.schemas.evals_schema import EvalsSchema
 
 
 def brute_force_regex(text):
@@ -60,7 +61,8 @@ class EvalsParser(BaseParser):
         super().__init__(
             file="../data/evals.json",
             update=True,
-            driver=True
+            driver=True,
+            schema=EvalsSchema
         )
 
     def process(self):

--- a/data_parser/exams.py
+++ b/data_parser/exams.py
@@ -242,3 +242,5 @@ if __name__ == "__main__":
     p.process_utm()
     p.process_utsc()
     p.dump_file()
+    p.thread_print(f"Validating {p.file}...")
+    p.validate_dump()

--- a/data_parser/exams.py
+++ b/data_parser/exams.py
@@ -5,6 +5,7 @@ import requests
 from bs4 import BeautifulSoup
 
 from data_parser.base_parser import BaseParser
+from validations.schemas.exams_schema import ExamsSchema
 
 
 def get_course_info(month, year, course_code):
@@ -49,7 +50,8 @@ class ExamsParser(BaseParser):
     def __init__(self):
         super().__init__(
             file="../data/exams.json",
-            update=True
+            update=True,
+            schema=ExamsSchema
         )
 
     @staticmethod

--- a/data_parser/food.py
+++ b/data_parser/food.py
@@ -5,6 +5,7 @@ import requests
 from bs4 import BeautifulSoup
 
 from data_parser.base_parser import BaseParser
+from validations.schemas.food_schema import FoodSchema
 
 
 class FoodParser(BaseParser):
@@ -18,7 +19,8 @@ class FoodParser(BaseParser):
 
     def __init__(self):
         super().__init__(
-            file="../data/food.json"
+            file="../data/food.json",
+            schema=FoodSchema
         )
 
     def process(self):

--- a/data_parser/parking.py
+++ b/data_parser/parking.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import requests
 
 from data_parser.base_parser import BaseParser
-
+from validations.schemas.parking_schema import ParkingSchema
 
 class ParkingParser(BaseParser):
     link = "http://map.utoronto.ca"
@@ -17,7 +17,8 @@ class ParkingParser(BaseParser):
 
     def __init__(self):
         super().__init__(
-            file="../data/parking.json"
+            file="../data/parking.json",
+            schema=ParkingSchema
         )
 
     def process(self):

--- a/data_parser/services.py
+++ b/data_parser/services.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import requests
 
 from data_parser.base_parser import BaseParser
-
+from validations.schemas.services_schema import ServicesSchema
 
 class ServicesParser(BaseParser):
     link = "http://map.utoronto.ca"
@@ -17,7 +17,8 @@ class ServicesParser(BaseParser):
 
     def __init__(self):
         super().__init__(
-            file="../data/services.json"
+            file="../data/services.json",
+            schema=ServicesSchema
         )
 
     def process(self):

--- a/data_parser/textbooks.py
+++ b/data_parser/textbooks.py
@@ -8,7 +8,7 @@ import requests
 from bs4 import BeautifulSoup
 
 from data_parser.base_parser import BaseParser
-
+from validations.schemas.textbooks_schema import TextbooksSchema
 
 # Make full use of cobalt's existing code
 class TextbooksParser(BaseParser):
@@ -24,7 +24,8 @@ class TextbooksParser(BaseParser):
     def __init__(self):
         super().__init__(
             file="../data/textbooks.json",
-            threads=10
+            threads=10,
+            schema=TextbooksSchema
         )
 
     def fill_queue(self):

--- a/data_parser/textbooks.py
+++ b/data_parser/textbooks.py
@@ -341,3 +341,5 @@ if __name__ == "__main__":
     p.queue.join()
     p.clean_up()
     p.dump_file()
+    p.thread_print(f"Validating {p.file}...")
+    p.validate_dump()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ beautifulsoup4
 requests
 lxml
 python-dateutil
+schema==0.7.2

--- a/validations/README.md
+++ b/validations/README.md
@@ -1,0 +1,11 @@
+# Validation & Data Integrity
+This module handles the schemas and validation process for all parsers. Each parser has it's own schema under the `schemas` module.
+
+To validate a JSON output against a particular schema, you can do something like:
+```python
+from validations.data_validator import DataValidator
+
+d = DataValidator()
+d.run_validation(data, CoursesSchema)   # Returns error, if any
+```
+while replacing `data` and `CoursesSchema` with the appropriate objects.

--- a/validations/data_validator.py
+++ b/validations/data_validator.py
@@ -36,14 +36,14 @@ class DataValidator:
 
                 # If we get something back, it means it wasn't successful
                 if result:
-                    self.failed.append({ 'course': data_type, 'error': result })
+                    self.failed.append({ 'type': data_type, 'error': result })
                     print('Failed')
                 else:
                     print('Passed')
         
         for failure in self.failed:
             print("\n" + ('*' * 10))
-            print(f'Validation failed for {failure["course"]}')
+            print(f'Validation failed for {failure["type"]}')
             print(f"Stacktrace:\n{failure['error']}\n")
 
         print(f'\nValidated {len(mapping)} schemas. {len(mapping) - len(self.failed)} passed, {len(self.failed)} failed.')

--- a/validations/data_validator.py
+++ b/validations/data_validator.py
@@ -1,19 +1,17 @@
 import json
 from schemas.buildings_schema import BuildingsSchema
-
-# from data_parser.food import FoodParser
-# from data_parser.evals import EvalsParser
-# from data_parser.exams import ExamsParser
-# from data_parser.courses import CoursesParser
-# from data_parser.parking import ParkingParser
-# from data_parser.services import ServicesParser
-# from data_parser.buildings import BuildingsParser
-# from data_parser.textbooks import TextbooksParser
+from schemas.courses_schema import CoursesSchema
 
 class DataValidator:
     json_mapping = {
-        'buildings': '../data/buildings.json',
-        'courses': 'courses.json',
+        'buildings': { 'file': '../data/buildings.json', 'klass': BuildingsSchema },
+        'courses': '../data/courses.json',
+        'evals': '../data/evals.json',
+        'exams': '../data/exams.json',
+        'food': '../data/food.json',
+        'parking': '../data/parking.json',
+        'services': '../data/services.json',
+        'textbooks': '../data/textbooks.json',
     }
 
     def __init__(self):
@@ -25,12 +23,9 @@ class DataValidator:
 if(__name__ == "__main__"):
     v = DataValidator()
 
-    with open('data/buildings.json', 'r') as f:
+    with open('data/buildings.json', 'r', encoding='utf8') as f:
         data = json.load(f)
 
-        # for b in data:
-        #     if b['tags'] is None:
-        #         print(b['code'])
         print(BuildingsSchema.is_valid(data))
 
 

--- a/validations/data_validator.py
+++ b/validations/data_validator.py
@@ -1,6 +1,12 @@
 import json
 from schemas.buildings_schema import BuildingsSchema
 from schemas.courses_schema import CoursesSchema
+from schemas.evals_schema import EvalsSchema
+from schemas.exams_schema import ExamsSchema
+from schemas.food_schema import FoodSchema
+from schemas.parking_schema import ParkingSchema
+from schemas.services_schema import ServicesSchema
+from schemas.textbooks_schema import TextbooksSchema
 
 class DataValidator:
     json_mapping = {
@@ -27,9 +33,10 @@ class DataValidator:
 
 if(__name__ == "__main__"):
 
-    with open('data/buildings.json', 'r', encoding='utf8') as f:
+    with open('data/textbooks.json', 'r', encoding='utf8') as f:
         data = json.load(f)
 
-        print(DataValidator.is_valid(data, BuildingsSchema))
+        print(DataValidator.validate(data, TextbooksSchema))
+        print(DataValidator.is_valid(data, TextbooksSchema))
 
 

--- a/validations/data_validator.py
+++ b/validations/data_validator.py
@@ -10,33 +10,60 @@ from schemas.textbooks_schema import TextbooksSchema
 
 class DataValidator:
     json_mapping = {
-        'buildings': { 'file': '../data/buildings.json', 'klass': BuildingsSchema },
-        'courses': '../data/courses.json',
-        'evals': '../data/evals.json',
-        'exams': '../data/exams.json',
-        'food': '../data/food.json',
-        'parking': '../data/parking.json',
-        'services': '../data/services.json',
-        'textbooks': '../data/textbooks.json',
+        'buildings':    {'file': 'data/buildings.json', 'klass': BuildingsSchema},
+        'courses':      {'file': 'data/courses.json', 'klass': CoursesSchema},
+        'evals':        {'file': 'data/evals.json', 'klass': EvalsSchema},
+        'exams':        {'file': 'data/exams.json', 'klass': ExamsSchema},
+        'food':         {'file': 'data/food.json', 'klass': FoodSchema},
+        'parking':      {'file': 'data/parking.json', 'klass': ParkingSchema},
+        'services':     {'file': 'data/services.json', 'klass': ServicesSchema},
+        'textbooks':    {'file': 'data/textbooks.json', 'klass': TextbooksSchema},
     }
 
     def __init__(self):
-        pass
+        self.failed = []
+
+    def run_all_validations(self):
+        mapping = DataValidator.json_mapping
+
+        for data_type in mapping:
+            with open(mapping[data_type]['file'], 'r', encoding='utf8') as f:
+                data = json.load(f)
+                print(f'Validating {data_type}...', end='', flush=True)
+
+                result = self.run_validation(data, mapping[data_type]['klass'])
+
+                # If we get something back, it means it wasn't successful
+                if(result):
+                    self.failed.append({ 'course': data_type, 'error': result })
+                    print('Failed')
+                else:
+                    print('Passed')
+        
+        for failure in self.failed:
+            print("\n" + ('*' * 10))
+            print(f'Validation failed for {failure["course"]}')
+            print(f"Stacktrace:\n{failure['error']}\n")
+
+            
+        print(f'\nValidated {len(mapping)} schemas. {len(mapping) - len(self.failed)} passed, {len(self.failed)} failed.')
+    
+    def run_validation(self, obj, schema):
+        try:
+            DataValidator.validate_with_exception(obj, schema)
+        except BaseException as error:
+            return error
 
     @staticmethod
-    def validate(json_data, schema):
+    def validate_with_exception(json_data, schema):
         return schema.SCHEMA.validate(json_data)
-    
+
     @staticmethod
     def is_valid(json_data, schema):
         return schema.SCHEMA.is_valid(json_data)
 
 if(__name__ == "__main__"):
-
-    with open('data/textbooks.json', 'r', encoding='utf8') as f:
-        data = json.load(f)
-
-        print(DataValidator.validate(data, TextbooksSchema))
-        print(DataValidator.is_valid(data, TextbooksSchema))
+    v = DataValidator()
+    v.run_all_validations()
 
 

--- a/validations/data_validator.py
+++ b/validations/data_validator.py
@@ -17,15 +17,19 @@ class DataValidator:
     def __init__(self):
         pass
 
-    def validate_json(self, json_data, schema):
-        pass
+    @staticmethod
+    def validate(json_data, schema):
+        return schema.SCHEMA.validate(json_data)
+    
+    @staticmethod
+    def is_valid(json_data, schema):
+        return schema.SCHEMA.is_valid(json_data)
 
 if(__name__ == "__main__"):
-    v = DataValidator()
 
     with open('data/buildings.json', 'r', encoding='utf8') as f:
         data = json.load(f)
 
-        print(BuildingsSchema.is_valid(data))
+        print(DataValidator.is_valid(data, BuildingsSchema))
 
 

--- a/validations/data_validator.py
+++ b/validations/data_validator.py
@@ -1,0 +1,36 @@
+import json
+from schemas.buildings_schema import BuildingsSchema
+
+# from data_parser.food import FoodParser
+# from data_parser.evals import EvalsParser
+# from data_parser.exams import ExamsParser
+# from data_parser.courses import CoursesParser
+# from data_parser.parking import ParkingParser
+# from data_parser.services import ServicesParser
+# from data_parser.buildings import BuildingsParser
+# from data_parser.textbooks import TextbooksParser
+
+class DataValidator:
+    json_mapping = {
+        'buildings': '../data/buildings.json',
+        'courses': 'courses.json',
+    }
+
+    def __init__(self):
+        pass
+
+    def validate_json(self, json_data, schema):
+        pass
+
+if(__name__ == "__main__"):
+    v = DataValidator()
+
+    with open('data/buildings.json', 'r') as f:
+        data = json.load(f)
+
+        # for b in data:
+        #     if b['tags'] is None:
+        #         print(b['code'])
+        print(BuildingsSchema.is_valid(data))
+
+

--- a/validations/data_validator.py
+++ b/validations/data_validator.py
@@ -1,23 +1,24 @@
 import json
-from schemas.buildings_schema import BuildingsSchema
-from schemas.courses_schema import CoursesSchema
-from schemas.evals_schema import EvalsSchema
-from schemas.exams_schema import ExamsSchema
-from schemas.food_schema import FoodSchema
-from schemas.parking_schema import ParkingSchema
-from schemas.services_schema import ServicesSchema
-from schemas.textbooks_schema import TextbooksSchema
+from schema import SchemaError
+from validations.schemas.buildings_schema import BuildingsSchema
+from validations.schemas.courses_schema import CoursesSchema
+from validations.schemas.evals_schema import EvalsSchema
+from validations.schemas.exams_schema import ExamsSchema
+from validations.schemas.food_schema import FoodSchema
+from validations.schemas.parking_schema import ParkingSchema
+from validations.schemas.services_schema import ServicesSchema
+from validations.schemas.textbooks_schema import TextbooksSchema
 
 class DataValidator:
     json_mapping = {
-        'buildings':    {'file': 'data/buildings.json', 'klass': BuildingsSchema},
-        'courses':      {'file': 'data/courses.json', 'klass': CoursesSchema},
-        'evals':        {'file': 'data/evals.json', 'klass': EvalsSchema},
-        'exams':        {'file': 'data/exams.json', 'klass': ExamsSchema},
-        'food':         {'file': 'data/food.json', 'klass': FoodSchema},
-        'parking':      {'file': 'data/parking.json', 'klass': ParkingSchema},
-        'services':     {'file': 'data/services.json', 'klass': ServicesSchema},
-        'textbooks':    {'file': 'data/textbooks.json', 'klass': TextbooksSchema},
+        'buildings':    {'file': '../data/buildings.json', 'klass': BuildingsSchema},
+        'courses':      {'file': '../data/courses.json', 'klass': CoursesSchema},
+        'evals':        {'file': '../data/evals.json', 'klass': EvalsSchema},
+        'exams':        {'file': '../data/exams.json', 'klass': ExamsSchema},
+        'food':         {'file': '../data/food.json', 'klass': FoodSchema},
+        'parking':      {'file': '../data/parking.json', 'klass': ParkingSchema},
+        'services':     {'file': '../data/services.json', 'klass': ServicesSchema},
+        'textbooks':    {'file': '../data/textbooks.json', 'klass': TextbooksSchema},
     }
 
     def __init__(self):
@@ -49,9 +50,11 @@ class DataValidator:
         print(f'\nValidated {len(mapping)} schemas. {len(mapping) - len(self.failed)} passed, {len(self.failed)} failed.')
     
     def run_validation(self, obj, schema):
+        '''Returns truthy object if failed, None if passed.
+        '''
         try:
             DataValidator.validate_with_exception(obj, schema)
-        except BaseException as error:
+        except SchemaError as error:
             return error
 
     @staticmethod
@@ -61,6 +64,7 @@ class DataValidator:
     @staticmethod
     def is_valid(json_data, schema):
         return schema.SCHEMA.is_valid(json_data)
+
 
 if(__name__ == "__main__"):
     v = DataValidator()

--- a/validations/data_validator.py
+++ b/validations/data_validator.py
@@ -35,7 +35,7 @@ class DataValidator:
                 result = self.run_validation(data, mapping[data_type]['klass'])
 
                 # If we get something back, it means it wasn't successful
-                if(result):
+                if result:
                     self.failed.append({ 'course': data_type, 'error': result })
                     print('Failed')
                 else:
@@ -46,12 +46,11 @@ class DataValidator:
             print(f'Validation failed for {failure["course"]}')
             print(f"Stacktrace:\n{failure['error']}\n")
 
-            
         print(f'\nValidated {len(mapping)} schemas. {len(mapping) - len(self.failed)} passed, {len(self.failed)} failed.')
     
     def run_validation(self, obj, schema):
-        '''Returns truthy object if failed, None if passed.
-        '''
+        """Returns truthy object if failed, None if passed.
+        """
         try:
             DataValidator.validate_with_exception(obj, schema)
         except SchemaError as error:

--- a/validations/schemas/base_schema.py
+++ b/validations/schemas/base_schema.py
@@ -7,6 +7,6 @@ class BaseSchema:
     VALID_CAMPUSES = ['St. George', 'Scarborough', 'Mississauga']
 
     # Lambda Methods
-    COURSE_CODE_LAMBDA = lambda code: 7 <= len(code) <= 9
+    COURSE_CODE_LAMBDA = lambda code: 7 <= len(code) <= 10
 
     # Static Helpers

--- a/validations/schemas/base_schema.py
+++ b/validations/schemas/base_schema.py
@@ -1,0 +1,8 @@
+class BaseSchema:
+    # Constants
+    VALID_CAMPUSES = ['St. George', 'Scarborough', 'Mississauga']
+
+    # Lambda Methods
+    COURSE_CODE_LAMBDA = lambda code: 7 <= len(code) <= 9
+
+    # Static Helpers

--- a/validations/schemas/base_schema.py
+++ b/validations/schemas/base_schema.py
@@ -1,4 +1,8 @@
+from schema import Schema
+
 class BaseSchema:
+    SCHEMA = Schema({})
+
     # Constants
     VALID_CAMPUSES = ['St. George', 'Scarborough', 'Mississauga']
 

--- a/validations/schemas/buildings_schema.py
+++ b/validations/schemas/buildings_schema.py
@@ -1,5 +1,5 @@
 from schema import Schema, And, Or
-from schemas.base_schema import BaseSchema
+from validations.schemas.base_schema import BaseSchema
 
 class BuildingsSchema(BaseSchema):
     SCHEMA = Schema([{

--- a/validations/schemas/buildings_schema.py
+++ b/validations/schemas/buildings_schema.py
@@ -20,12 +20,4 @@ class BuildingsSchema:
         },
         'last_updated': str
     }])
-
-    @staticmethod
-    def validate(obj):
-        return BuildingsSchema.SCHEMA.validate(obj)
-
-    @staticmethod
-    def is_valid(obj):
-        return BuildingsSchema.SCHEMA.is_valid(obj)
     

--- a/validations/schemas/buildings_schema.py
+++ b/validations/schemas/buildings_schema.py
@@ -1,6 +1,7 @@
 from schema import Schema, And, Or
+from schemas.base_schema import BaseSchema
 
-class BuildingsSchema:
+class BuildingsSchema(BaseSchema):
     SCHEMA = Schema([{
         'id': str,
         'code': Or(And(str, lambda code: len(code) == 2), None),   # Building code should be a string and of length 2

--- a/validations/schemas/buildings_schema.py
+++ b/validations/schemas/buildings_schema.py
@@ -1,0 +1,31 @@
+from schema import Schema, And, Or
+
+class BuildingsSchema:
+    SCHEMA = Schema([{
+        'id': str,
+        'code': Or(And(str, lambda code: len(code) == 2), None),   # Building code should be a string and of length 2
+        'tags': Or(str, None),
+        'name': str,
+        'short_name': Or(str, None),
+        'address': {
+            'street': Or(str, None),
+            'city': Or(str, None),
+            'province': Or(str, None),
+            'country': Or(str, None),
+            'postal': Or(str, None),
+        },
+        'coordinates': {
+            'latitude': Or(float, None),
+            'longitude': Or(float, None)
+        },
+        'last_updated': str
+    }])
+
+    @staticmethod
+    def validate(obj):
+        return BuildingsSchema.SCHEMA.validate(obj)
+
+    @staticmethod
+    def is_valid(obj):
+        return BuildingsSchema.SCHEMA.is_valid(obj)
+    

--- a/validations/schemas/courses_schema.py
+++ b/validations/schemas/courses_schema.py
@@ -1,5 +1,5 @@
 from schema import Schema, And, Or
-from schemas.base_schema import BaseSchema
+from validations.schemas.base_schema import BaseSchema
 
 class CoursesSchema(BaseSchema):
     SCHEMA = Schema([{

--- a/validations/schemas/courses_schema.py
+++ b/validations/schemas/courses_schema.py
@@ -1,0 +1,48 @@
+from schema import Schema, And, Or
+
+class CoursesSchema:
+    SCHEMA = Schema([{
+        'id': str,
+        'code': Or(And(str, lambda code: len(code) == 8), None),   # Building code should be a string and of length 2
+        'name': str,
+        'description': str,
+        'division': str,
+        'department': str,
+        'prerequisites': Or(str, None),
+        'corequisites': Or(str, None),
+        'exclusions': Or(str, None),
+        'recommended_preparation': Or(str, None),
+        'level': str,
+        'campus': Or(*['St. George', 'Scarborough', 'Mississauga']),
+        'term': str,
+        'arts_and_science_breadth': Or(str, None),
+        'arts_and_science_distribution': Or(str, None),
+        'utm_distribution': Or(str, None),
+        'utsc_breadth': Or(str, None),
+        'apsc_electives': Or(str, None),
+        'meeting_sections': [{
+            'code': str,
+            'instructors': list,
+            'times': [{
+                'day': str,
+                'start': int,
+                'end': int,
+                'duration': int,
+                'location': Or(str, None)
+            }],
+            'size': int,
+            'enrollment': Or(int, None),
+            'waitlist_option': bool,
+            'delivery': str
+        }],
+        'last_updated': Or(str, None)
+    }])
+
+    @staticmethod
+    def validate(obj):
+        return CoursesSchema.SCHEMA.is_valid(obj)
+
+    @staticmethod
+    def is_valid(obj):
+        return CoursesSchema.SCHEMA.is_valid(obj)
+    

--- a/validations/schemas/courses_schema.py
+++ b/validations/schemas/courses_schema.py
@@ -1,11 +1,10 @@
 from schema import Schema, And, Or
+from schemas.base_schema import BaseSchema
 
-class CoursesSchema:
-    VALID_CAMPUSES = ['St. George', 'Scarborough', 'Mississauga']
-
+class CoursesSchema(BaseSchema):
     SCHEMA = Schema([{
         'id': str,
-        'code': Or(And(str, lambda code: len(code) == 8), None),   # Building code should be a string and of length 2
+        'code': Or(And(str, BaseSchema.COURSE_CODE_LAMBDA), None),   # Building code should be a string and of length 8
         'name': str,
         'description': str,
         'division': str,
@@ -15,7 +14,7 @@ class CoursesSchema:
         'exclusions': Or(str, None),
         'recommended_preparation': Or(str, None),
         'level': str,
-        'campus': Or(*VALID_CAMPUSES),
+        'campus': Or(*BaseSchema.VALID_CAMPUSES),
         'term': str,
         'arts_and_science_breadth': Or(str, None),
         'arts_and_science_distribution': Or(str, None),

--- a/validations/schemas/courses_schema.py
+++ b/validations/schemas/courses_schema.py
@@ -1,6 +1,8 @@
 from schema import Schema, And, Or
 
 class CoursesSchema:
+    VALID_CAMPUSES = ['St. George', 'Scarborough', 'Mississauga']
+
     SCHEMA = Schema([{
         'id': str,
         'code': Or(And(str, lambda code: len(code) == 8), None),   # Building code should be a string and of length 2
@@ -13,7 +15,7 @@ class CoursesSchema:
         'exclusions': Or(str, None),
         'recommended_preparation': Or(str, None),
         'level': str,
-        'campus': Or(*['St. George', 'Scarborough', 'Mississauga']),
+        'campus': Or(*VALID_CAMPUSES),
         'term': str,
         'arts_and_science_breadth': Or(str, None),
         'arts_and_science_distribution': Or(str, None),
@@ -37,12 +39,4 @@ class CoursesSchema:
         }],
         'last_updated': Or(str, None)
     }])
-
-    @staticmethod
-    def validate(obj):
-        return CoursesSchema.SCHEMA.is_valid(obj)
-
-    @staticmethod
-    def is_valid(obj):
-        return CoursesSchema.SCHEMA.is_valid(obj)
     

--- a/validations/schemas/evals_schema.py
+++ b/validations/schemas/evals_schema.py
@@ -1,5 +1,5 @@
 from schema import Schema, And, Or
-from schemas.base_schema import BaseSchema
+from validations.schemas.base_schema import BaseSchema
 
 class EvalsSchema(BaseSchema):
     SCHEMA = Schema([{

--- a/validations/schemas/evals_schema.py
+++ b/validations/schemas/evals_schema.py
@@ -1,0 +1,27 @@
+from schema import Schema, And, Or
+from schemas.base_schema import BaseSchema
+
+class EvalsSchema(BaseSchema):
+    SCHEMA = Schema([{
+        'id': str,
+        'name': str,
+        'campus': Or(*BaseSchema.VALID_CAMPUSES),
+        'terms': [{
+            'term': str,
+            'lectures': [{
+                'lecture_code': str,
+                'firstname': str,
+                'lastname': str,
+                's1': Or(float, None),
+                's2': Or(float, None),
+                's3': Or(float, None),
+                's4': Or(float, None),
+                's5': Or(float, None),
+                's6': Or(float, None),
+                'invited': Or(int, None),
+                'responses': int
+            }]
+        }],
+        'last_updated': Or(str, None)
+    }])
+    

--- a/validations/schemas/exams_schema.py
+++ b/validations/schemas/exams_schema.py
@@ -1,5 +1,5 @@
 from schema import Schema, And, Or
-from schemas.base_schema import BaseSchema
+from validations.schemas.base_schema import BaseSchema
 
 class ExamsSchema(BaseSchema):
     SCHEMA = Schema([{

--- a/validations/schemas/exams_schema.py
+++ b/validations/schemas/exams_schema.py
@@ -1,0 +1,21 @@
+from schema import Schema, And, Or
+from schemas.base_schema import BaseSchema
+
+class ExamsSchema(BaseSchema):
+    SCHEMA = Schema([{
+        'id': str,
+        'course_id': str,
+        'course_code': And(str, BaseSchema.COURSE_CODE_LAMBDA),
+        'campus': Or(*BaseSchema.VALID_CAMPUSES),
+        'date': str,
+        'start': int,
+        'end': int,
+        'duration': int,
+        'sections': [{
+            'lecture_code': str,
+            'split': str,
+            'location': Or(str, None)
+        }],
+        'last_updated': Or(str, None)
+    }])
+    

--- a/validations/schemas/food_schema.py
+++ b/validations/schemas/food_schema.py
@@ -1,5 +1,5 @@
 from schema import Schema, And, Or, Optional
-from schemas.base_schema import BaseSchema
+from validations.schemas.base_schema import BaseSchema
 
 class FoodSchema(BaseSchema):
     SCHEMA = Schema([{

--- a/validations/schemas/food_schema.py
+++ b/validations/schemas/food_schema.py
@@ -1,0 +1,60 @@
+from schema import Schema, And, Or, Optional
+from schemas.base_schema import BaseSchema
+
+class FoodSchema(BaseSchema):
+    SCHEMA = Schema([{
+        'id': str,
+        'name': str,
+        'description': Or(str, None),
+        'campus': Or(*BaseSchema.VALID_CAMPUSES),
+        'tags': Or(str, None),
+        'address': Or(str, None),
+        'coordinates': {
+            'latitude': float,
+            'longitude': float
+        },
+        'hours': Or(None, {}, {
+            'sunday': {
+                'closed': bool,
+                'open': Or(int, None),
+                'close': Or(int, None)
+            },
+            'monday': {
+                'closed': bool,
+                'open': Or(int, None),
+                'close': Or(int, None)
+            },
+            'tuesday': {
+                'closed': bool,
+                'open': Or(int, None),
+                'close': Or(int, None)
+            },
+            'wednesday': {
+                'closed': bool,
+                'open': Or(int, None),
+                'close': Or(int, None)
+            },
+            'thursday': {
+                'closed': bool,
+                'open': Or(int, None),
+                'close': Or(int, None)
+            },
+            'friday': {
+                'closed': bool,
+                'open': Or(int, None),
+                'close': Or(int, None)
+            },
+            'saturday': Or(None, {
+                'closed': bool,
+                'open': Or(int, None),
+                'close': Or(int, None)
+            }),
+        }),
+        'image': Or(str, None),
+        'url': Or(str, None),
+        'twitter': Or(str, None),
+        'facebook': Or(str, None),
+        Optional('attributes'): list,       # attributes is optional. If it exists, it should be a list
+        'last_updated': Or(str, None)
+    }])
+    

--- a/validations/schemas/parking_schema.py
+++ b/validations/schemas/parking_schema.py
@@ -1,5 +1,5 @@
 from schema import Schema, And, Or
-from schemas.base_schema import BaseSchema
+from validations.schemas.base_schema import BaseSchema
 
 class ParkingSchema(BaseSchema):
     SCHEMA = Schema([{

--- a/validations/schemas/parking_schema.py
+++ b/validations/schemas/parking_schema.py
@@ -1,0 +1,19 @@
+from schema import Schema, And, Or
+from schemas.base_schema import BaseSchema
+
+class ParkingSchema(BaseSchema):
+    SCHEMA = Schema([{
+        'id': str,
+        'name': str,
+        'alias': Or(str, None),
+        'building_id': Or(str, None),
+        'description': Or(str, None),
+        'campus': Or(*BaseSchema.VALID_CAMPUSES),
+        'address': Or(str, None),
+        'coordinates': {
+            'latitude': float,
+            'longitude': float
+        },
+        'last_updated': Or(str, None)
+    }])
+    

--- a/validations/schemas/services_schema.py
+++ b/validations/schemas/services_schema.py
@@ -1,0 +1,22 @@
+from schema import Schema, And, Or, Optional
+from schemas.base_schema import BaseSchema
+
+class ServicesSchema(BaseSchema):
+    SCHEMA = Schema([{
+        'id': str,
+        'name': str,
+        'alias': Or(str, None),
+        'building_id': Or(str, None),
+        'description': Or(str, None),
+        'campus': Or(*BaseSchema.VALID_CAMPUSES),
+        'address': Or(str, None),
+        'image': Or(str, None),
+        'coordinates': {
+            'latitude': float,
+            'longitude': float
+        },
+        'tags': Or(str, None),
+        Optional('attributes'): list,
+        'last_updated': Or(str, None)
+    }])
+    

--- a/validations/schemas/services_schema.py
+++ b/validations/schemas/services_schema.py
@@ -1,5 +1,5 @@
 from schema import Schema, And, Or, Optional
-from schemas.base_schema import BaseSchema
+from validations.schemas.base_schema import BaseSchema
 
 class ServicesSchema(BaseSchema):
     SCHEMA = Schema([{

--- a/validations/schemas/textbooks_schema.py
+++ b/validations/schemas/textbooks_schema.py
@@ -1,5 +1,5 @@
 from schema import Schema, And, Or, Optional
-from schemas.base_schema import BaseSchema
+from validations.schemas.base_schema import BaseSchema
 
 class TextbooksSchema(BaseSchema):
     SCHEMA = Schema([{

--- a/validations/schemas/textbooks_schema.py
+++ b/validations/schemas/textbooks_schema.py
@@ -1,0 +1,25 @@
+from schema import Schema, And, Or, Optional
+from schemas.base_schema import BaseSchema
+
+class TextbooksSchema(BaseSchema):
+    SCHEMA = Schema([{
+        'id': str,
+        'isbn': str,
+        'title': str,
+        'edition': Or(str, int),
+        'author': str,
+        'image': str,
+        'price': float,
+        'url': str,
+        'courses': [{
+            'id': str,
+            'code': And(str, BaseSchema.COURSE_CODE_LAMBDA),
+            'requirement': str,
+            'meeting_sections': [{
+                'code': str,
+                'instructors': list
+            }]
+        }],
+        'last_updated': Or(str, None)
+    }])
+    


### PR DESCRIPTION
The main addition is the schemas and validation logic for all existing parser. The validations are set to run at the _end_, and they are completed via loading the JSON dumps and checking against their respective schema.

In the event of a validation failure, the following occurs:
1. An error message is printed to console, indicating the validation did not complete successfully
2. A text file with a stack trace of the error is created, with the format  `file_name.json_DEBUG_{time_stamp}.txt`. For example: `buildings.json_DEBUG_123456.7890.txt`

The schema's have been tested against the current data sets, and appear to be passing. 

Resolves #4. 